### PR TITLE
Add support to 'nearby_stations' feed.

### DIFF
--- a/gbfs/client.py
+++ b/gbfs/client.py
@@ -1,12 +1,17 @@
 import datetime
 import requests
 
+from string import Formatter
 
 from gbfs.data.fetchers import RemoteJSONFetcher
 from gbfs.const import gbfs_client_default_language
 
 
 __all__ = ['GBFSClient']
+
+
+def parse_tags(s):
+    return [t[1] for t in Formatter().parse(s) if t[1] is not None]
 
 
 class GBFSClient(object):
@@ -48,10 +53,14 @@ class GBFSClient(object):
     def feed_names(self):
         return list(self.feeds.keys())
 
-    def request_feed(self, feed_name):
+    def request_feed(self, feed_name, **kwargs):
         url = self.feeds.get(feed_name)
         if url is None:
             raise Exception('Feed name must be one of: {}'.format(','.join(self.feed_names)))
+
+        if kwargs:
+            assert sorted(kwargs.keys()) == sorted(parse_tags(url))
+            url = url.format(**kwargs)
 
         data = self._json_fetcher.fetch(url)
 


### PR DESCRIPTION
Hi, 

There are some services, such as https://barcelona.publicbikesystem.net/ube/gbfs/v1/gbfs.json, that support a "nearby_stations" endpoint, combining the  "station_status" endpoint with the station_id tag. So here is a PR to support any kind of feed that must contain a tag to be formated. 

If you feel the helper function should be implemented in other pattern, I'm happy to modify it.

Ismael