### PR TITLE
Add scheduled workflow to keep bundled systems.csv in sync with upstream

### DIFF
--- a/.github/workflows/update-systems-csv.yml
+++ b/.github/workflows/update-systems-csv.yml
@@ -1,0 +1,57 @@
+name: Update systems.csv
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # every Monday at 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch latest systems.csv
+        run: |
+          curl -sSLf -o /tmp/systems.csv https://raw.githubusercontent.com/NABSA/gbfs/master/systems.csv
+
+      - name: Validate downloaded file before replacing local copy
+        run: |
+          lines=$(wc -l < /tmp/systems.csv)
+          header=$(head -1 /tmp/systems.csv)
+          echo "Downloaded file has $lines lines"
+          echo "Header: $header"
+
+          if [ "$lines" -lt 100 ]; then
+            echo "::error::Downloaded systems.csv has suspiciously few lines ($lines); refusing to update."
+            exit 1
+          fi
+
+          case "$header" in
+            "Country Code,Name,Location,System ID,URL,Auto-Discovery URL"*) ;;
+            *)
+              echo "::error::Downloaded systems.csv has an unexpected header; refusing to update."
+              exit 1
+              ;;
+          esac
+
+          cp /tmp/systems.csv gbfs/static/systems.csv
+
+      - name: Open pull request if systems.csv changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Update bundled systems.csv from upstream NABSA/gbfs"
+          title: "Update bundled systems.csv from upstream"
+          body: |
+            Automated refresh of `gbfs/static/systems.csv` from
+            https://raw.githubusercontent.com/NABSA/gbfs/master/systems.csv
+
+            Opened by the scheduled `Update systems.csv` workflow. See #13 for background
+            on why this file needs to stay in sync with upstream.
+          branch: update-systems-csv
+          delete-branch: true
+          labels: automated


### PR DESCRIPTION
## Summary
- New GitHub Actions workflow (`.github/workflows/update-systems-csv.yml`), scheduled weekly (Mondays 06:00 UTC) plus manual `workflow_dispatch`
- Fetches the live upstream `systems.csv` from `NABSA/gbfs`, validates line count and header shape before accepting it (refuses to overwrite the bundled file with a truncated or malformed download)
- Opens a PR via `peter-evans/create-pull-request` only when the fetched file actually differs from what's committed — no direct pushes to `master`, so a human still reviews each data update

## Why this shape
- Not done at build/install time: fetching over the network during packaging makes builds non-deterministic and breaks offline/air-gapped installs
- Not done in the regular test suite: would make unrelated PRs flaky depending on network access to GitHub

## Note
This PR only adds the automation — it does not itself refresh the currently-stale `gbfs/static/systems.csv` (tracked in #13). The first scheduled or manually-dispatched run of this workflow will open a separate, automated PR with the actual data update.

Refs #13

## Test plan
- [x] Validated the fetch/validation shell logic locally against the real upstream CSV (line count + header checks both pass)
- [x] Confirmed the workflow YAML parses correctly
- [ ] First live run (scheduled or manually dispatched via `workflow_dispatch`) to confirm the `peter-evans/create-pull-request` step behaves as expected end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)