### PR TITLE
Stop hardcoding a real-world system ID in test_services.py

### DIFF
--- a/gbfs/tests/test_services.py
+++ b/gbfs/tests/test_services.py
@@ -15,6 +15,7 @@ def test_system_discovery_service():
     assert ds.systems
     assert ds.system_ids
     assert len(ds.systems) == len(ds.system_ids)
-    assert ds.get_system_by_id('ABU')
+    first_id = next(iter(ds.system_ids))
+    assert ds.get_system_by_id(first_id)
     assert ds._instantiate_client(os.path.join(package_tests_fixtures_dirpath, 'gbfs.json'), 'en',
                                   json_fetcher=LocalJSONFetcher())


### PR DESCRIPTION
## Summary
PR #14 (the scheduled systems.csv update workflow) merged before this follow-up commit was pushed to the same branch, so it never made it into `master`. Re-opening as its own PR.

`test_services.py` hardcoded `'ABU'` (ADCB Bikeshare) as a known-good system ID. That's fragile: it's a real-world ID living in mutable upstream data, and the whole point of the new scheduled workflow (#14) is that this data will now change regularly. Replaced the hardcoded ID with an assertion against whatever the first row's system ID actually is, so the test can't go stale on future refreshes.

## Test plan
- [x] `pytest` passes (8/8) against the current bundled `systems.csv`