### PR TITLE
Fix stale Coveralls badge and re-wire coverage upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,14 @@ jobs:
 
       - name: Report coverage
         run: coverage report -m
+
+      - name: Generate lcov coverage report
+        if: matrix.python-version == '3.13'
+        run: coverage lcov -o coverage.lcov
+
+      - name: Upload coverage to Coveralls
+        if: matrix.python-version == '3.13'
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage.lcov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 bikeshare-client-python
 -----------------------
 [![Test](https://github.com/jakehadar/bikeshare-client-python/actions/workflows/test.yml/badge.svg)](https://github.com/jakehadar/bikeshare-client-python/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/jakehadar/bikeshare-client/badge.svg?branch=coverage)](https://coveralls.io/github/jakehadar/bikeshare-client?branch=coverage)
+[![Coverage Status](https://coveralls.io/repos/github/jakehadar/bikeshare-client-python/badge.svg?branch=master)](https://coveralls.io/github/jakehadar/bikeshare-client-python?branch=master)
 
 A Python client for discovering and capturing live bikeshare data feeds made publically available by [hundreds of global bikeshare providers](https://raw.githubusercontent.com/NABSA/gbfs/master/systems.csv) in accordance with the [General Bikeshare Feed Specification (GBFS)](https://github.com/NABSA/gbfs/blob/master/gbfs.md) standard.
 


### PR DESCRIPTION
## Summary
The Coveralls badge hasn't updated since ~2019 for two separate reasons:

1. **Wrong badge URL**: pointed at `jakehadar/bikeshare-client` (missing `-python`) on `branch=coverage`, not this repo's actual slug or default branch. Even with fresh data flowing, this badge would never have rendered it.
2. **No upload path exists anymore**: the old `.travis.yml` ran `coveralls` in `after_success`; when Travis was replaced with GitHub Actions, nothing replaced that upload step. The `Test` workflow computes coverage locally (`coverage report -m`) but never sends it anywhere.

## Changes
- Fixed the badge URL/link to `jakehadar/bikeshare-client-python` on `branch=master`
- Added a coverage upload step to `.github/workflows/test.yml`: generates an lcov report via `coverage lcov`, uploads via `coverallsapp/github-action@v2`
- Gated the upload to a single matrix leg (Python 3.13) rather than all 6, to avoid submitting conflicting reports for the same commit
- Uses the Coveralls GitHub App integration (`GITHUB_TOKEN`) rather than a stored repo token secret

## Before merging
**Repo must be enabled on coveralls.io first**: log into coveralls.io with GitHub, use the GitHub App integration to add `bikeshare-client-python`. Without that, the upload step will fail (nothing to receive the report).

## Test plan
- [x] Verified `coverage lcov -o coverage.lcov` produces a valid LCOV report locally (Python 3.8, coverage.py 7.6.1)
- [x] Workflow YAML parses correctly
- [ ] First live run after merge, once the repo is enabled on coveralls.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)