### PR TITLE
Force GitHub to use the version of Node.js that it wants to use

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It was failing a test and GitHub said to change from Node.js 20 to Node.js 24. So, I followed the instructions. Now the tests are all passing...